### PR TITLE
Fix mono issues

### DIFF
--- a/linuxserver.io/plex.xml
+++ b/linuxserver.io/plex.xml
@@ -51,6 +51,11 @@
       <ContainerDir>/config</ContainerDir>
       <Mode>rw</Mode>
     </Volume>
+    <Volume>
+      <HostDir>/dev/rtc</HostDir>
+      <ContainerDir>/dev/rtc</ContainerDir>
+      <Mode>ro</Mode>
+    </Volume>
   </Data>
 <WebUI>http://[IP]:[PORT:32400]/web</WebUI>
   <Banner>https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/plex-banner.png</Banner>


### PR DESCRIPTION
Update plex template to implement /dev/rtc:ro to fix mono crash issue…s when trying to run schedule actions.

https://github.com/linuxserver/docker-sonarr/pull/6