### PR TITLE
Update unifi.xml

### DIFF
--- a/linuxserver.io/unifi.xml
+++ b/linuxserver.io/unifi.xml
@@ -55,6 +55,11 @@
         <ContainerPort>8880</ContainerPort>
         <Protocol>tcp</Protocol>
       </Port>
+      <Port>
+        <HostPort>3478</HostPort>
+        <ContainerPort>3478</ContainerPort>
+        <Protocol>udp</Protocol>
+      </Port>      
     </Publish>
   </Networking>
   <Data>


### PR DESCRIPTION
With beta 5.6.7, warnings appear on the controller if the STUN server is not available.  This is accessible over port 3478/UDP. - https://community.ubnt.com/t5/UniFi-Routing-Switching-Beta/UniFi-5-6-7-Warning-Message/m-p/1950197#U1950197