### PR TITLE
Letsencrypt tls

### DIFF
--- a/linuxserver.io/letsencrypt.xml
+++ b/linuxserver.io/letsencrypt.xml
@@ -83,6 +83,7 @@
     <Variable>
       <Value>false</Value>
       <Name>HTTPVAL</Name>
+    </Variable>
   </Environment>
   <Config Name="http" Target="80" Default="" Mode="tcp" Description="Container Port: 80" Type="Port" Display="always" Required="false" Mask="false"></Config>
   <Config Name="https" Target="443" Default="" Mode="tcp" Description="Container Port: 443" Type="Port" Display="always" Required="false" Mask="false"></Config>

--- a/linuxserver.io/letsencrypt.xml
+++ b/linuxserver.io/letsencrypt.xml
@@ -80,6 +80,9 @@
       <Value>100</Value>
       <Name>PGID</Name>
     </Variable>
+    <Variable>
+      <Value>false</Value>
+      <Name>HTTPVAL</Name>
   </Environment>
   <Config Name="http" Target="80" Default="" Mode="tcp" Description="Container Port: 80" Type="Port" Display="always" Required="false" Mask="false"></Config>
   <Config Name="https" Target="443" Default="" Mode="tcp" Description="Container Port: 443" Type="Port" Display="always" Required="false" Mask="false"></Config>
@@ -90,6 +93,7 @@
   <Config Name="Diffie Hellman" Target="DHLEVEL" Default="2048" Mode="" Description="Diffie Hellman parameters bit value.  Can be 1024, 2048 or 4096.  (Default is 2048)" Type="Variable" Display="always" Required="false" Mask="false"></Config>
   <Config Name="PUID" Target="PUID" Default="99" Mode="" Description="UID for permissions.  Do not change unless you know what you're doing." Type="Variable" Display="advanced-hide" Required="true" Mask="false"></Config>
   <Config Name="PGID" Target="PGID" Default="100" Mode="" Description="GID for permissions.  Do not change unless you know what you're doing." Type="Variable" Display="advanced-hide" Required="true" Mask="false"></Config>
+  <Config Name="HTTPVAL" Target="HTTPVAL" Default="false" Mode="" Description="Flag to switch validation method to HTTP (over port 80) if set to 'true'" Type="Variable" Display="advanced-hide" Required="false" Mask="false"></Config>
   <Config Name="AppData Config Path" Target="/config" Default="/mnt/user/appdata/letsencrypt" Mode="rw" Description="Container Path: /config" Type="Path" Display="always" Required="true" Mask="false"></Config>
 <DonateText>Donations</DonateText>
 <DonateLink>https://www.linuxserver.io/donations/</DonateLink>


### PR DESCRIPTION
Gives unRAID users the option to set the HTTPVAL options to avoid the tls issue.