### PR TITLE
Remove Beta tag

### DIFF
--- a/linuxserver.io/radarr.xml
+++ b/linuxserver.io/radarr.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Container>
   <TemplateURL>https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/radarr.xml</TemplateURL>
-  <Beta>True</Beta>
   <Category>Downloaders: MediaApp:Video Status:Beta</Category>
   <Date>2017-04-17</Date>
   <Name>radarr</Name>


### PR DESCRIPTION
If something is "Beta", CA will not flag it as being recommended.