### PR TITLE
Mask MYSQL_ROOT_PASSWORD Environment Variable.

### DIFF
--- a/linuxserver.io/mariadb.xml
+++ b/linuxserver.io/mariadb.xml
@@ -48,6 +48,7 @@ An Enhanced drop in replacement for Mysql[br]
       <Mode>rw</Mode>
     </Volume>
   </Data>
+  <Config Name="Key 3" Target="MYSQL_ROOT_PASSWORD" Default="0" Mode="" Description="Container Variable: MYSQL_ROOT_PASSWORD" Type="Variable" Display="always" Required="false" Mask="true">0</Config>
 <WebUI></WebUI>
   <Icon>https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/mariadb-icon.png</Icon>
 <DonateText>Donations</DonateText>


### PR DESCRIPTION
Currently, the MYSQL_ROOT_PASSWORD Environment Variable is not masked.
Since it is a password field, it should be masked.